### PR TITLE
Included Number of tickets property on Event

### DIFF
--- a/src/GogoKit/Models/Response/Event.cs
+++ b/src/GogoKit/Models/Response/Event.cs
@@ -13,6 +13,9 @@ namespace GogoKit.Models.Response
         [DataMember(Name = "min_ticket_price")]
         public Money MinTicketPrice { get; set; }
 
+        [DataMember(Name = "number_of_tickets")]
+        public int NumberOfTickets { get; set; }
+
         [DataMember(Name = "notes_html")]
         public string Notes { get; set; }
 

--- a/src/GogoKit/Models/Response/Event.cs
+++ b/src/GogoKit/Models/Response/Event.cs
@@ -14,7 +14,7 @@ namespace GogoKit.Models.Response
         public Money MinTicketPrice { get; set; }
 
         [DataMember(Name = "number_of_tickets")]
-        public int NumberOfTickets { get; set; }
+        public int? NumberOfTickets { get; set; }
 
         [DataMember(Name = "notes_html")]
         public string Notes { get; set; }


### PR DESCRIPTION
Event didn't have NumberOfTickets property according to documentation. The only way to get it was to request the listings for events. 

Thus if we need to display the ticket availability for many Events it becomes expensive operation without a need.