### PR TITLE
Fix ViagogoCatalogClient and add properties to Event, Category and Venue

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -3,8 +3,9 @@
     <VersionPrefix>4.0.0-beta-6</VersionPrefix>
     <PackageReleaseNotes>
       ### New in 4.0.0-beta-6
-      * Add `ExternalMappings to Event, EmbeddedCategory and Venue
-      * Add Type to Event
+      * Fix `ViagogoCatalogClient` root API URL being used
+      * Add `ExternalMappings` to `Event`, `EmbeddedCategory` and `Venue`
+      * Add `Type` to `Event`
     </PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/Version.props
+++ b/Version.props
@@ -1,9 +1,10 @@
 ﻿<Project>
   <PropertyGroup>
-    <VersionPrefix>4.0.0-beta-5</VersionPrefix>
+    <VersionPrefix>4.0.0-beta-6</VersionPrefix>
     <PackageReleaseNotes>
-      ### New in 4.0.0-beta-5
-      * Add venue catalog client
+      ### New in 4.0.0-beta-6
+      * Add `ExternalMappings to Event, EmbeddedCategory and Venue
+      * Add Type to Event
     </PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/src/GogoKit/Enumerations/EventType.cs
+++ b/src/GogoKit/Enumerations/EventType.cs
@@ -1,0 +1,13 @@
+﻿using System.Runtime.Serialization;
+
+namespace GogoKit.Enumerations
+{
+    [DataContract]
+    public enum EventType
+    {
+        [EnumMember]
+        Main,
+        [EnumMember]
+        Parking
+    }
+}

--- a/src/GogoKit/GogoKit.csproj
+++ b/src/GogoKit/GogoKit.csproj
@@ -9,6 +9,7 @@
     <Authors>viagogo</Authors>
     <License>https://raw.githubusercontent.com/viagogo/gogokit.net/master/LICENSE.txt</License>
     <Description>GogoKit is a lightweight, async viagogo API client library for .NET.</Description>
+    <GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/GogoKit/GogoKitConfiguration.cs
+++ b/src/GogoKit/GogoKitConfiguration.cs
@@ -107,7 +107,7 @@ namespace GogoKit
             {
                 _apiEnvironment = value;
                 ViagogoApiRootEndpoint = Default.ViagogoApiRootEndpoints[_apiEnvironment];
-                ViagogoCatalogApiRootEndpoint = Default.ViagogoApiRootEndpoints[_apiEnvironment];
+                ViagogoCatalogApiRootEndpoint = Default.ViagogoCatalogApiRootEndpoints[_apiEnvironment];
                 ViagogoOAuthTokenEndpoint = Default.ViagogoOAuthTokenEndpoints[_apiEnvironment];
                 ViagogoAuthorizationEndpoint = Default.ViagogoAuthorizationEndpoints[_apiEnvironment];
             }

--- a/src/GogoKit/Http/HttpConnectionBuilder.cs
+++ b/src/GogoKit/Http/HttpConnectionBuilder.cs
@@ -25,6 +25,11 @@ namespace GogoKit.Http
             return new HttpConnectionBuilder(configuration, product, ConnectionType.Api, serializer);
         }
 
+        public static HttpConnectionBuilder CatalogApiConnection(IGogoKitConfiguration configuration, ProductHeaderValue product, IJsonSerializer serializer)
+        {
+            return new HttpConnectionBuilder(configuration, product, ConnectionType.CatalogApi, serializer);
+        }
+
         public static HttpConnectionBuilder OAuthConnection(IGogoKitConfiguration configuration, ProductHeaderValue product, IJsonSerializer serializer)
         {
             return new HttpConnectionBuilder(configuration, product, ConnectionType.OAuth, serializer);
@@ -93,6 +98,7 @@ namespace GogoKit.Http
                         break;
                     }
                 case ConnectionType.Api:
+                case ConnectionType.CatalogApi:
                     {
                         var oauthConnection = OAuthConnection(_configuration, _product, _serializer)
                                                 .LocalizationProvider(_localizationProvider)
@@ -109,7 +115,10 @@ namespace GogoKit.Http
                     }
             }
 
-            var halKitConfiguration = new HalKitConfiguration(_configuration.ViagogoApiRootEndpoint)
+            var rootEndpoint = _connectionType == ConnectionType.CatalogApi
+                ? _configuration.ViagogoCatalogApiRootEndpoint
+                : _configuration.ViagogoApiRootEndpoint;
+            var halKitConfiguration = new HalKitConfiguration(rootEndpoint)
             {
                 CaptureSynchronizationContext = _configuration.CaptureSynchronizationContext
             };
@@ -137,7 +146,8 @@ namespace GogoKit.Http
         private enum ConnectionType
         {
             OAuth,
-            Api
+            Api,
+            CatalogApi
         }
     }
 }

--- a/src/GogoKit/IViagogoCatalogClient.cs
+++ b/src/GogoKit/IViagogoCatalogClient.cs
@@ -1,15 +1,11 @@
 ﻿using GogoKit.Clients;
-using GogoKit.Services;
 using HalKit;
 
 namespace GogoKit
 {
     public interface IViagogoCatalogClient
     {
-        IGogoKitConfiguration Configuration { get; }
         IHalClient Hypermedia { get; }
-        IOAuth2TokenStore TokenStore { get; }
-        IOAuth2Client OAuth2 { get; }
         IEventsClient Events { get; }
         IVenuesClient Venues { get; }
     }

--- a/src/GogoKit/Models/Response/EmbeddedCategory.cs
+++ b/src/GogoKit/Models/Response/EmbeddedCategory.cs
@@ -4,20 +4,28 @@ using HalKit.Json;
 
 namespace GogoKit.Models.Response
 {
+    /// <summary>
+    /// A Category represents a grouping of events or other categories. Examples are “Concerts”, “Rock and Pop” and “Lady Gaga”.
+    /// </summary>
     [DataContract]
     public class EmbeddedCategory : Resource
     {
+        /// <summary>
+        /// The category identifier.
+        /// </summary>
         [DataMember(Name = "id")]
         public int? Id { get; set; }
 
+        /// <summary>
+        /// The name of the category.
+        /// </summary>
         [DataMember(Name = "name")]
         public string Name { get; set; }
 
         /// <summary>
-        /// You can GET the href of this link to retrieve the image for a
-        /// <see cref="Category"/>.
+        /// The external mappings for this category.
         /// </summary>
-        [Rel("category:image")]
-        public Link ImageLink { get; set; }
+        [Embedded("external_mappings")]
+        public EmbeddedExternalMappingResource[] ExternalMappings { get; set; }
     }
 }

--- a/src/GogoKit/Models/Response/EmbeddedExternalMapping.cs
+++ b/src/GogoKit/Models/Response/EmbeddedExternalMapping.cs
@@ -1,0 +1,23 @@
+﻿using System.Runtime.Serialization;
+
+namespace GogoKit.Models.Response
+{
+    /// <summary>
+    /// An external mapping between a resource on the viagogo platform and the same resource on another platforms. 
+    /// </summary>
+    [DataContract]
+    public class EmbeddedExternalMappingResource
+    {
+        /// <summary>
+        /// The identifier of the resource in the external platform
+        /// </summary>
+        [DataMember(Name = "id")]
+        public string Id { get; set; }
+
+        /// <summary>
+        /// The name of the external platform. Can be `legacy_stubhub`.
+        /// </summary>
+        [DataMember(Name = "platform_name")]
+        public string PlatformName { get; set; }
+    }
+}

--- a/src/GogoKit/Models/Response/EmbeddedVenue.cs
+++ b/src/GogoKit/Models/Response/EmbeddedVenue.cs
@@ -4,31 +4,64 @@ using HalKit.Models.Response;
 
 namespace GogoKit.Models.Response
 {
+    /// <summary>
+    /// An venue on the viagogo platform.
+    /// </summary>
     [DataContract]
     public class EmbeddedVenue : Resource
     {
+        /// <summary>
+        /// The venue identifier.
+        /// </summary>
         [DataMember(Name = "id")]
         public int? Id { get; set; }
 
+        /// <summary>
+        /// The name of the venue.
+        /// </summary>
         [DataMember(Name = "name")]
         public string Name { get; set; }
 
+        /// <summary>
+        /// The name of the city where the venue is located.
+        /// </summary>
         [DataMember(Name = "city")]
         public string City { get; set; }
 
+        /// <summary>
+        /// The name of the State or Province where the venue is located.
+        /// </summary>
         [DataMember(Name = "state_province")]
         public string StateProvince { get; set; }
-        
+
+        /// <summary>
+        /// The postal code for the venue.
+        /// </summary>
         [DataMember(Name = "postal_code")]
         public string PostalCode { get; set; }
 
+        /// <summary>
+        /// The latitude for the venue.
+        /// </summary>
         [DataMember(Name = "latitude")]
         public double? Latitude { get; set; }
 
+        /// <summary>
+        /// The longitude for the venue.
+        /// </summary>
         [DataMember(Name = "longitude")]
         public double? Longitude { get; set; }
 
+        /// <summary>
+        /// The <see cref="Country"/> where the venue is located.
+        /// </summary>
         [Embedded("country")]
         public Country Country { get; set; }
+
+        /// <summary>
+        /// The external mappings for this venue.
+        /// </summary>
+        [Embedded("external_mappings")]
+        public EmbeddedExternalMappingResource[] ExternalMappings { get; set; }
     }
 }

--- a/src/GogoKit/Models/Response/Event.cs
+++ b/src/GogoKit/Models/Response/Event.cs
@@ -1,9 +1,8 @@
 ﻿using HalKit.Json;
 using HalKit.Models.Response;
 using System;
-using System.Collections.Generic;
 using System.Runtime.Serialization;
-using System.Text;
+using GogoKit.Enumerations;
 
 namespace GogoKit.Models.Response
 {
@@ -50,6 +49,12 @@ namespace GogoKit.Models.Response
         public bool DateConfirmed { get; set; }
 
         /// <summary>
+        /// The <see cref="EventType"/> of the event.
+        /// </summary>
+        [DataMember(Name = "type")]
+        public EventType Type { get; set; }
+
+        /// <summary>
         /// The minimum ticket price of the event.
         /// </summary>
         [DataMember(Name = "min_ticket_price")]
@@ -62,21 +67,27 @@ namespace GogoKit.Models.Response
         public Link WebPageLink { get; set; }
 
         /// <summary>
+        /// The categories for this event.
+        /// </summary>
+        [Embedded("categories")]
+        public EmbeddedCategory[] Categories { get; set; }
+
+        /// <summary>
         /// The venue where the event is taking place.
         /// </summary>
         [Embedded("venue")]
         public EmbeddedVenue Venue { get; set; }
 
         /// <summary>
-        /// The categories for this event.
-        /// </summary>
-        [Embedded("categories")]
-        public IReadOnlyList<EmbeddedCategory> Categories { get; set; }
-
-        /// <summary>
         /// The genre for this event.
         /// </summary>
         [Embedded("genre")]
         public EmbeddedCategory Genre { get; set; }
+
+        /// <summary>
+        /// The external mappings for this event
+        /// </summary>
+        [Embedded("external_mappings")]
+        public EmbeddedExternalMappingResource[] ExternalMappings { get; set; }
     }
 }

--- a/src/GogoKit/Models/Response/Venue.cs
+++ b/src/GogoKit/Models/Response/Venue.cs
@@ -2,6 +2,9 @@
 
 namespace GogoKit.Models.Response
 {
+    /// <summary>
+    /// An venue on the viagogo platform.
+    /// </summary>
     [DataContract]
     public class Venue : EmbeddedVenue
     {

--- a/src/GogoKit/Services/LinkFactory.cs
+++ b/src/GogoKit/Services/LinkFactory.cs
@@ -6,13 +6,13 @@ namespace GogoKit.Services
 {
     public class LinkFactory : ILinkFactory
     {
-        private readonly IGogoKitConfiguration _configuration;
+        private readonly Uri _viagogoApiRootEndpoint;
 
-        public LinkFactory(IGogoKitConfiguration configuration)
+        public LinkFactory(Uri viagogoApiRootEndpoint)
         {
-            Requires.ArgumentNotNull(configuration, nameof(configuration));
+            Requires.ArgumentNotNull(viagogoApiRootEndpoint, nameof(viagogoApiRootEndpoint));
 
-            _configuration = configuration;
+            _viagogoApiRootEndpoint = viagogoApiRootEndpoint;
         }
 
         public async Task<Link> CreateLinkAsync(string relativeUriFormat, params object[] args)
@@ -20,7 +20,7 @@ namespace GogoKit.Services
             Requires.ArgumentNotNull(relativeUriFormat, nameof(relativeUriFormat));
 
             var relativeUri = string.Format(relativeUriFormat, args);
-            var href = new Uri(_configuration.ViagogoApiRootEndpoint, $"{_configuration.ViagogoApiRootEndpoint}/{relativeUri}");
+            var href = new Uri(_viagogoApiRootEndpoint, $"{_viagogoApiRootEndpoint}/{relativeUri}");
 
             return new Link { HRef = href.ToString() };
         }

--- a/src/GogoKit/ViagogoCatalogClient.cs
+++ b/src/GogoKit/ViagogoCatalogClient.cs
@@ -1,104 +1,26 @@
-using System.Collections.Generic;
-using System.Net.Http;
-using System.Net.Http.Headers;
 using GogoKit.Clients;
-using GogoKit.Http;
 using GogoKit.Services;
 using HalKit;
 using HalKit.Http;
-using HalKit.Json;
 
 namespace GogoKit
 {
     internal class ViagogoCatalogClient : IViagogoCatalogClient
     {
-        public ViagogoCatalogClient(
-            ProductHeaderValue product,
-            string clientId,
-            string clientSecret)
-            : this(product, new GogoKitConfiguration(clientId, clientSecret), new InMemoryOAuth2TokenStore())
+        public ViagogoCatalogClient(IHttpConnection catalogApiConnection)
         {
-        }
+            Requires.ArgumentNotNull(catalogApiConnection, nameof(catalogApiConnection));
 
-        public ViagogoCatalogClient(
-            ProductHeaderValue product,
-            IGogoKitConfiguration configuration,
-            IOAuth2TokenStore tokenStore)
-            : this(product,
-                   configuration,
-                   tokenStore,
-                   new ConfigurationLocalizationProvider(configuration),
-                   new DefaultJsonSerializer(),
-                   new HttpClientHandler(),
-                   new DelegatingHandler[] { })
-        {
-        }
-
-        public ViagogoCatalogClient(
-           ProductHeaderValue product,
-           IGogoKitConfiguration configuration,
-           IOAuth2TokenStore tokenStore,
-           ILocalizationProvider localizationProvider,
-           IJsonSerializer serializer,
-           HttpClientHandler httpClientHandler,
-           IList<DelegatingHandler> customHandlers)
-            : this(product,
-                   configuration,
-                   tokenStore,
-                   serializer,
-                   HttpConnectionBuilder.OAuthConnection(configuration, product, serializer)
-                                        .LocalizationProvider(localizationProvider)
-                                        .HttpClientHandler(httpClientHandler)
-                                        .AdditionalHandlers(customHandlers)
-                                        .Build(),
-                   HttpConnectionBuilder.ApiConnection(configuration, product, serializer)
-                                        .TokenStore(tokenStore)
-                                        .LocalizationProvider(localizationProvider)
-                                        .HttpClientHandler(httpClientHandler)
-                                        .AdditionalHandlers(customHandlers)
-                                        .Build())
-        {
-        }
-
-        public ViagogoCatalogClient(
-            ProductHeaderValue product,
-            IGogoKitConfiguration configuration,
-            IOAuth2TokenStore tokenStore,
-            IJsonSerializer serializer,
-            IHttpConnection oauthConnection,
-            IHttpConnection apiConnection)
-        {
-            Requires.ArgumentNotNull(product, nameof(product));
-            Requires.ArgumentNotNull(configuration, nameof(configuration));
-            Requires.ArgumentNotNull(tokenStore, nameof(tokenStore));
-            Requires.ArgumentNotNull(serializer, nameof(serializer));
-            Requires.ArgumentNotNull(oauthConnection, nameof(oauthConnection));
-            Requires.ArgumentNotNull(apiConnection, nameof(apiConnection));
-
-            var halKitConfiguration = new HalKitConfiguration(configuration.ViagogoCatalogApiRootEndpoint)
-            {
-                CaptureSynchronizationContext = configuration.CaptureSynchronizationContext
-            };
-
-            var linkFactory = new LinkFactory(configuration);
-
-            Configuration = configuration;
-            TokenStore = tokenStore;
-            Hypermedia = new HalClient(halKitConfiguration, apiConnection);
-            OAuth2 = new OAuth2Client(oauthConnection, configuration);
+            var linkFactory = new LinkFactory(catalogApiConnection.Configuration.RootEndpoint);
+            Hypermedia = new HalClient(catalogApiConnection.Configuration, catalogApiConnection);
             Events = new EventClient(Hypermedia, linkFactory);
             Venues = new VenuesClient(Hypermedia, linkFactory);
         }
 
-        public IGogoKitConfiguration Configuration { get; }
-
         public IHalClient Hypermedia { get; }
 
-        public IOAuth2TokenStore TokenStore { get; }
-
-        public IOAuth2Client OAuth2 { get; }
-
         public IEventsClient Events { get; }
+
         public IVenuesClient Venues { get; }
     }
 }


### PR DESCRIPTION
- ViagogoCatalogClient wasn't actually calling the Catalog API because it was using a connection that used the v2 root endpoint 😞 
- Add `ExternalMappings` property and `Event`, `EmbeddedCategory` and `EmbeddedVenue`
- Add `Type` property to `Event`