### PR TITLE
Fixes to HalClientExtensions.GetChangedResourcesAsync

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -1,11 +1,10 @@
 ﻿<Project>
   <PropertyGroup>
-    <VersionPrefix>4.0.0-beta-6</VersionPrefix>
+    <VersionPrefix>4.0.0-beta-7</VersionPrefix>
     <PackageReleaseNotes>
-      ### New in 4.0.0-beta-6
-      * Fix `ViagogoCatalogClient` root API URL being used
-      * Add `ExternalMappings` to `Event`, `EmbeddedCategory` and `Venue`
-      * Add `Type` to `Event`
+      ### New in 4.0.0-beta-7
+      * Fix stopping conditions for HalClientExtensions.GetChangedResourcesAsync
+      * Return partial results when API calls fail while doing HalClientExtensions.GetChangedResourcesAsync
     </PackageReleaseNotes>
   </PropertyGroup>
 </Project>

--- a/src/GogoKit/Clients/EventClient.cs
+++ b/src/GogoKit/Clients/EventClient.cs
@@ -50,7 +50,8 @@ namespace GogoKit.Clients
             return new ChangedResources<Event>(
                 changedResources.NewOrUpdatedResources.GroupBy(l => l.Id).Select(l => l.Last()).ToList(),
                 changedResources.DeletedResources.GroupBy(l => l.Id).Select(l => l.First()).ToList(),
-                changedResources.NextLink);
+                changedResources.NextLink,
+                changedResources.FailureException);
         }
     }
 }

--- a/src/GogoKit/Clients/SalesClient.cs
+++ b/src/GogoKit/Clients/SalesClient.cs
@@ -101,7 +101,8 @@ namespace GogoKit.Clients
             return new ChangedResources<Sale>(
                 changedResources.NewOrUpdatedResources.GroupBy(l => l.Id).Select(l => l.OrderByDescending(o => o.UpdatedAt ?? o.CreatedAt).First()).ToList(),
                 changedResources.DeletedResources.GroupBy(l => l.Id).Select(l => l.First()).ToList(),
-                changedResources.NextLink);
+                changedResources.NextLink,
+                changedResources.FailureException);
         }
 
         public async Task<IReadOnlyList<TicketHolderResource>> GetTicketHolderDetailsAsync(int saleId, CancellationToken cancellationToken)

--- a/src/GogoKit/Clients/SellerListingsClient.cs
+++ b/src/GogoKit/Clients/SellerListingsClient.cs
@@ -115,7 +115,8 @@ namespace GogoKit.Clients
             return new ChangedResources<SellerListing>(
                 changedResources.NewOrUpdatedResources.GroupBy(l => l.Id).Select(l => l.OrderByDescending(o => o.UpdatedAt).First()).ToList(), 
                 changedResources.DeletedResources.GroupBy(l => l.Id).Select(l => l.First()).ToList(),
-                changedResources.NextLink);
+                changedResources.NextLink,
+                changedResources.FailureException);
         }
 
         public Task<ListingConstraints> GetConstraintsAsync(long sellerListingId)

--- a/src/GogoKit/Clients/VenuesClient.cs
+++ b/src/GogoKit/Clients/VenuesClient.cs
@@ -49,7 +49,8 @@ namespace GogoKit.Clients
             return new ChangedResources<Venue>(
                 changedResources.NewOrUpdatedResources.GroupBy(l => l.Id).Select(l => l.Last()).ToList(),
                 changedResources.DeletedResources.GroupBy(l => l.Id).Select(l => l.First()).ToList(),
-                changedResources.NextLink);
+                changedResources.NextLink,
+                changedResources.FailureException);
         }
     }
 }

--- a/src/GogoKit/Extensions/HalClientExtensions.cs
+++ b/src/GogoKit/Extensions/HalClientExtensions.cs
@@ -179,7 +179,8 @@ namespace GogoKit
                         deletedItems.AddRange(currentPage.DeletedItems);
                     }
 
-                    if (currentPage.NextLink == null)
+                    if (currentPage.NextLink == null ||
+                        currentPage.Items.Count == 0 && currentPage.DeletedItems?.Any() != true)
                     {
                         // This is the last page
                         break;

--- a/src/GogoKit/Extensions/HalClientExtensions.cs
+++ b/src/GogoKit/Extensions/HalClientExtensions.cs
@@ -158,37 +158,45 @@ namespace GogoKit
                 currentParameters.Add("page_size", maxPageSize);
             }
 
+            Exception failureException = null;
             var items = new List<T>();
             var deletedItems = new List<T>();
             while (true)
             {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                var currentPage = await client.GetAsync<PagedResource<T>>(
-                                            currentLink,
-                                            currentParameters,
-                                            headers,
-                                            cancellationToken).ConfigureAwait(client.Configuration);
-
-                items.AddRange(currentPage.Items);
-                if (currentPage.DeletedItems != null)
+                try
                 {
-                    deletedItems.AddRange(currentPage.DeletedItems);
-                }
+                    cancellationToken.ThrowIfCancellationRequested();
 
-                if (currentPage.NextLink == null)
+                    var currentPage = await client.GetAsync<PagedResource<T>>(
+                        currentLink,
+                        currentParameters,
+                        headers,
+                        cancellationToken).ConfigureAwait(client.Configuration);
+
+                    items.AddRange(currentPage.Items);
+                    if (currentPage.DeletedItems != null)
+                    {
+                        deletedItems.AddRange(currentPage.DeletedItems);
+                    }
+
+                    if (currentPage.NextLink == null)
+                    {
+                        // This is the last page
+                        break;
+                    }
+
+                    // Stop passing parameters on subsequent calls since the "next" links
+                    // will already be assembled with all the parameters needed
+                    currentParameters = null;
+                    currentLink = currentPage.NextLink;
+                }
+                catch (Exception ex)
                 {
-                    // This is the last page
-                    break;
+                    failureException = ex;
                 }
-
-                // Stop passing parameters on subsequent calls since the "next" links
-                // will already be assembled with all the parameters needed
-                currentParameters = null;
-                currentLink = currentPage.NextLink;
             }
 
-            return new ChangedResources<T>(items, deletedItems, currentLink);
+            return new ChangedResources<T>(items, deletedItems, currentLink, failureException);
         }
     }
 }

--- a/src/GogoKit/Extensions/HalClientExtensions.cs
+++ b/src/GogoKit/Extensions/HalClientExtensions.cs
@@ -194,6 +194,7 @@ namespace GogoKit
                 catch (Exception ex)
                 {
                     failureException = ex;
+                    break;
                 }
             }
 

--- a/src/GogoKit/Models/Response/ResourceChanges.cs
+++ b/src/GogoKit/Models/Response/ResourceChanges.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using HalKit.Models.Response;
 
 namespace GogoKit.Models.Response
@@ -10,9 +11,11 @@ namespace GogoKit.Models.Response
     /// <remarks>See http://developer.viagogo.net/#getting-resource-changes-since-your-last-request</remarks>
     public class ChangedResources<T> where T : Resource
     {
-        public ChangedResources(IReadOnlyList<T> newOrUpdatedResources,
-                                IReadOnlyList<T> deletedResources,
-                                Link nextLink)
+        internal ChangedResources(
+            IReadOnlyList<T> newOrUpdatedResources,
+            IReadOnlyList<T> deletedResources,
+            Link nextLink,
+            Exception failureException)
         {
             Requires.ArgumentNotNull(newOrUpdatedResources, nameof(newOrUpdatedResources));
             Requires.ArgumentNotNull(deletedResources, nameof(deletedResources));
@@ -20,6 +23,7 @@ namespace GogoKit.Models.Response
             NewOrUpdatedResources = newOrUpdatedResources;
             DeletedResources = deletedResources;
             NextLink = nextLink;
+            FailureException = failureException;
         }
 
         /// <summary>
@@ -37,5 +41,16 @@ namespace GogoKit.Models.Response
         /// <typeparamref name="T"/> resource changes.
         /// </summary>
         public Link NextLink { get; }
+
+        /// <summary>
+        /// True if all changes were retrieved (since the previous request made by your application);
+        /// Otherwise, false.
+        /// </summary>
+        public bool AreAllChangesSuccessfullyRetrieved => FailureException != null;
+
+        /// <summary>
+        /// The <see cref="Exception"/> that occurred while retrieving these changes.
+        /// </summary>
+        public Exception FailureException { get; }
     }
 }

--- a/src/GogoKit/Models/Response/ResourceChanges.cs
+++ b/src/GogoKit/Models/Response/ResourceChanges.cs
@@ -46,7 +46,7 @@ namespace GogoKit.Models.Response
         /// True if all changes were retrieved (since the previous request made by your application);
         /// Otherwise, false.
         /// </summary>
-        public bool AreAllChangesSuccessfullyRetrieved => FailureException != null;
+        public bool AreAllChangesSuccessfullyRetrieved => FailureException == null;
 
         /// <summary>
         /// The <see cref="Exception"/> that occurred while retrieving these changes.


### PR DESCRIPTION
- Fix stopping conditions for `HalClientExtensions.GetChangedResourcesAsync`
- Return partial results when API calls fail while doing `HalClientExtensions.GetChangedResourcesAsync`