### PR TITLE
SAPI-214: Settle the Nuget Version

### DIFF
--- a/Version.props
+++ b/Version.props
@@ -1,7 +1,9 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>4.0.0-rc-6</VersionPrefix>
+        <VersionPrefix>4.0.0</VersionPrefix>
         <PackageReleaseNotes>
+            ### New in 4.0.0
+            * Official Release for 4.0.0-rc-6
             ### New in 4.0.0-rc-6
             * Adding is_auto_po to SellerListing GET and POST APIs
             ### New in 4.0.0-rc-5


### PR DESCRIPTION
It seems like some clients are still using version 3, but version 4 has been in the wild and is already in use by internal 

Running the following Kusto query 
```
DataStream_api
| where reqTime > ago(30d)
| where userAgent contains "GogoKit" or userAgent contains "GoGoKit"
| summarize count() by userAgent contains "4.0.0-rc"
```
In the last month, we get the following statistics for requests using the release candidate vs. the "stable" version:
version 3: 93,887,100 requests
version 4: 3,971,223 requests

Considering that we're getting decent traffic and that customer

Currently, the last stable version being used is version "3.4.2".  Which includes the RelistTransactionId update.  We are currently on 3.7.0.  
